### PR TITLE
Update PageTemplate.tsx

### DIFF
--- a/src/components/pageTemplate/PageTemplate.tsx
+++ b/src/components/pageTemplate/PageTemplate.tsx
@@ -1,22 +1,25 @@
-import React from 'react';
-// @ts-ignore
-import classNames from 'classnames/bind';
-import styles from './PageTemplate.module.scss';
+import React, {FunctionComponent} from 'react';
 
-const cx = classNames.bind(styles);
+
+
+
 
 interface Props {
 }
 
-const PageTemplate: React.FC<Props> = ({ children }) => {
+const PageTemplate: FunctionComponent<Props> = ({ children }) => {
     return (
-        <div className={cx('page-template')}>
+        <PageTemplate>
             <h1>일정 관리</h1>
             <div className={cx('content')}>
                 {children}
             </div>
-        </div>
+        </PageTemplate>
     );
 };
+
+const PageTemplate = styled.div`
+    // some styles
+`
 
 export default PageTemplate;


### PR DESCRIPTION
React.FC 대신
import React, {FunctionComponent} from 'react' 에서 FunctionComponent를 쓴다

PageTemplate 이라는 폴더가 이미 있기 때문에 굳이 index 패턴으로간다면
index.tsx파일과 index.scss 두가지 파일만 있으면 되지 않을까 싶다. PageTempate파일의 소스를 index.tsx 에 옮기고 이 파일은 삭제한다.
index.scss 로 파일명을 수정하고 import 'index.scss' 으로 scss-loader가 파일을 로드할 수 있지 않을까 싶다.

CN 보다 그냥 styled/component를 쓰는걸 권장한다. emotion이 더 잘 나가니 emotion을 써라 emotion의 styled component와 css 펑션을 사용한다면 신세계가 열린다